### PR TITLE
修复init失败,更新微信接口地址为https://wx2.qq.com

### DIFF
--- a/WeChat.NET/HTTP/WXService.cs
+++ b/WeChat.NET/HTTP/WXService.cs
@@ -18,19 +18,19 @@ namespace WeChat.NET.HTTP
         private static Dictionary<string, string> _syncKey = new Dictionary<string, string>();
 
         //微信初始化url
-        private static string _init_url = "https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxinit?r=1377482058764";
+        private static string _init_url = "https://wx2.qq.com/cgi-bin/mmwebwx-bin/webwxinit?r=1377482058764";
         //获取好友头像
-        private static string _geticon_url = "https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxgeticon?username=";
+        private static string _geticon_url = "https://wx2.qq.com/cgi-bin/mmwebwx-bin/webwxgeticon?username=";
         //获取群聊（组）头像
-        private static string _getheadimg_url = "https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxgetheadimg?username=";
+        private static string _getheadimg_url = "https://wx2.qq.com/cgi-bin/mmwebwx-bin/webwxgetheadimg?username=";
         //获取好友列表
-        private static string _getcontact_url = "https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxgetcontact";
+        private static string _getcontact_url = "https://wx2.qq.com/cgi-bin/mmwebwx-bin/webwxgetcontact";
         //同步检查url
         private static string _synccheck_url = "https://webpush.weixin.qq.com/cgi-bin/mmwebwx-bin/synccheck?sid={0}&uin={1}&synckey={2}&r={3}&skey={4}&deviceid={5}";
         //同步url
-        private static string _sync_url = "https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxsync?sid=";
+        private static string _sync_url = "https://wx2.qq.com/cgi-bin/mmwebwx-bin/webwxsync?sid=";
         //发送消息url
-        private static string _sendmsg_url = "https://wx.qq.com/cgi-bin/mmwebwx-bin/webwxsendmsg?sid=";
+        private static string _sendmsg_url = "https://wx2.qq.com/cgi-bin/mmwebwx-bin/webwxsendmsg?sid=";
 
         /// <summary>
         /// 微信初始化


### PR DESCRIPTION
因为微信网页版登录接口 https://login.weixin.qq.com/cgi-bin/mmwebwx-bin/login 返回的redirect_url 域名为 https://wx2.qq.com, 无法使用之前请求的cookie,所以导致init失败 这里将所有微信接口地址改为https://wx2.qq.com